### PR TITLE
Added contrast function and example.

### DIFF
--- a/examples/contrast_scanner.py
+++ b/examples/contrast_scanner.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+
+from gfxhat import lcd, backlight
+from PIL import Image, ImageFont, ImageDraw
+import time
+
+print("""contrast_scanner.py
+
+This example scans through the available contrast values, from 0-63,
+and displays this on the LCD. This is then repeated with the backlight
+set to white. You won't see anything for about 20 seconds each time 
+because values below around 25 aren't visible.
+
+Press Ctrl+C to exit.
+
+""")
+
+lm = ImageFont.truetype("/usr/share/fonts/truetype/liberation2/LiberationMono-Regular.ttf", 16)
+lm_big =  ImageFont.truetype("/usr/share/fonts/truetype/liberation2/LiberationMono-Regular.ttf", 56)
+
+
+lcd.show()
+
+backlight.set_all(0,0,0)
+backlight.show()
+
+
+def scan_contrast():
+	for c in range (0,64):
+		im = Image.new("1", (128,64), "black")
+		im2 = ImageDraw.Draw(im)
+
+		im2.text((19,0), "Contrast: ", 1, font=lm)
+
+		position = lm_big.getsize(str(c))
+		im2.text((64 - (position[0]/2), 10), str(c), 1, font=lm_big)
+		for x in range (128):
+			for y in range (64):
+				pixel = im.getpixel((x,y))
+				lcd.set_pixel(x, y, pixel)
+		lcd.contrast(c)
+		lcd.show()
+		time.sleep(0.5)
+	lcd.clear()
+	lcd.show()
+
+try:
+	lcd.contrast(0)
+	scan_contrast()
+
+	lcd.contrast(0)
+	backlight.set_all(255,255,255)
+	backlight.show()
+
+	scan_contrast()
+	lcd.contrast(0)
+
+	backlight.set_all(0,0,0)
+	backlight.show()
+	print("Done!")
+except KeyboardInterrupt:
+	lcd.contrast(0)
+	backlight.set_all(0,0,0)
+	backlight.show()
+	print("Quit via keyboard.")

--- a/library/gfxhat/lcd.py
+++ b/library/gfxhat/lcd.py
@@ -21,7 +21,9 @@ def set_pixel(x, y, value):
     """
     st7567.set_pixel(x, y, value)
 
-
 def show():
     """Update GFX HAT with the current buffer contents."""
     st7567.show()
+
+def contrast(value):
+    st7567.contrast(value)

--- a/library/gfxhat/st7567.py
+++ b/library/gfxhat/st7567.py
@@ -140,7 +140,7 @@ class ST7567:
             ST7567_DISPNORMAL,        # Inverse display (0xA6 normal)
             ST7567_SETSTARTLINE | 0,  # Start at line 0
             ST7567_POWERCTRL,
-            ST7567_REG_RATIO | 2,
+            ST7567_REG_RATIO | 3,
             ST7567_DISPON,
             ST7567_SETCONTRAST,       # Set contrast
             58                        # Contrast value
@@ -169,6 +169,8 @@ class ST7567:
             self._data(self.buf[offset:offset + ST7567_PAGESIZE])
         self._command([ST7567_EXIT_RMWMODE])
 
+    def contrast(self, value):
+        self._command([ST7567_SETCONTRAST,value])
 
 if __name__ == '__main__':
     st7567 = ST7567()


### PR DESCRIPTION
First off, apologies if I've done something dumb on the Git end, I've not done a lot with pull requests.

Anyway, I saw the Issue suggesting user-definable contrast and agreed it would be a great feature.  After a bit of manual testing I found that if you set the RegRatio to 3 then text would become visible above Electronic Volume values of ~25, and disappear into a dark background with values beginning at around 55.  

To that end, I've modified `st7567.py` to set the RegRatio to 3 during init, and added a function to both `st7567.py` and `lcd.py` called `contrast` which allows you to set the contrast.  I've allso added a small script (contrast_scanner.py) to the examples folder which scans through the contrast values, first with the backlight off and then all LEDs set to white, and displays the contrast value on the LCD with each contrast value.  Possibly not needed, but useful for seeing which contrast values actually work.

Any suggestions?  Is it worth setting the contrast function to head straight to an EV of ~20 with a user value of 0, or is it better to keep faint options for odd use cases?  I've just spotted that Gagetoid has assigned this to himself, so maybe he's already done much of this.